### PR TITLE
Add logging_restore_confs variable to restore backup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ These variables are set in the same level of the `logging_inputs`, `logging_outp
 - `logging_mark`: Mark message periodically by immark, if set to `true`. Default to `false`.
 - `logging_mark_interval`: Interval for `logging_mark` in seconds. Default to `3600`.
 - `logging_purge_confs`: `true` or `false`. If set to `true`, files in /etc/rsyslog.d are purged.
+- `logging_restore_confs`: `true` or `false`. If set to `true`, config files in the backup file are restored. This variable is to be used in the cleaning up.
 - `logging_system_log_dir`: Directory where the local log output files are placed. Default to `/var/log`.
 
 ### Update and Delete

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,9 @@ logging_flows: []
 # If logging_purge_confs is set to true, existing config files will be purged.
 logging_purge_confs: false
 
+# If logging_restore_confs is set to true, backed up config files are restored.
+logging_restore_confs: false
+
 # Variable to specify the directory to put the local output files to store logs.
 logging_system_log_dir: /var/log
 

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -76,8 +76,10 @@
 
         - name: Archive the contents of {{ __rsyslog_config_dir }} to
             the backup dir
+          vars:
+            __now: "{{ lookup('pipe', 'date +%s') }}"
           command: >
-            tar -cvzPf "{{ __rsyslog_backup_dir }}/backup.tgz"
+            tar -cvzPf "{{ __rsyslog_backup_dir }}/backup{{ __now }}.tgz"
                 /etc/rsyslog.conf "{{ __rsyslog_config_dir }}"
           args:
             warn: false  # suppress 'unarchive' warning
@@ -88,9 +90,28 @@
             set -euo pipefail
             /bin/rm -rfv {{ __rsyslog_config_dir }}/*
           when: __rsyslog_purge_original_conf | bool | d(false)
+
+        - block:
+            - name: Get backup files
+              shell: ls "{{ __rsyslog_backup_dir }}"
+              register: __backups
+
+            - name: Get backup file stat
+              stat:
+                path: "{{ __rsyslog_backup_dir }}/{{ __backups.stdout_lines[0] }}"
+              register: __backup_stat
+
+            - name: Restore original conf
+              shell: |-
+                # set -euo pipefail
+                tar -xvzPf "{{ __rsyslog_backup_dir }}/{{ __backups.stdout_lines[0] }}"
+              when: __backup_stat.stat.exists
+          when:
+            - __rsyslog_restore_original_conf | bool | d(false)
+
       vars:
         __rsyslog_backup_dir: '{{ rsyslog_backup_dir |
-          d("/tmp") }}/rsyslog.d-{{ ansible_date_time.iso8601_basic_short }}'
+          d("/var/tmp") }}/rsyslog.d-{{ ansible_date_time.iso8601_basic_short }}'
 
     - name: "Create logging directory if it does not exist or
       the ownership and/or modes are different."

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -131,6 +131,7 @@
   vars:
     __rsyslog_enabled: "{{ logging_enabled }}"
     __rsyslog_purge_original_conf: "{{ logging_purge_confs }}"
+    __rsyslog_restore_original_conf: "{{ logging_restore_confs }}"
     __rsyslog_system_log_dir: "{{ logging_system_log_dir }}"
   include_role:
     name: "{{ role_path }}/roles/rsyslog"

--- a/tests/tests_basics_files.yml
+++ b/tests/tests_basics_files.yml
@@ -372,6 +372,7 @@
 
     - name: END TEST CASE 3; Clean up the deployed config
       vars:
+        logging_restore_confs: true
         logging_enabled: false
         logging_outputs:
           - name: files_output0


### PR DESCRIPTION
This is a failed test example.
https://dl.fedoraproject.org/pub/alt/linuxsystemroles/logs/linux-system-roles-logging-pull-linux-system-roles_logging-240-618f22e-rhel-8-y-20220105-174527/artifacts/ansible.log

If `logging_purge_confs` is set to `true`, all the original config files are removed. Then, if cleaning up is done at the end as in the logging tests, it breaks the configuration and rsyslogd fails to start, which is the cause of the test failures.

To mitigate the issue, I'd like to propose to add `logging_restore_confs` variable to restore the conf files from backup if it is set to `true`. In the addition, I'm switching the default backup location from `/tmp` to `/var/tmp` to keep the backup in a bit safer place.